### PR TITLE
feat: add a11y CI workflow and fix lang toggle color contrast

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -1,0 +1,15 @@
+name: A11y Audit
+
+on:
+  pull_request:
+    branches: [master]
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: seoulcircle/a11y-audit@v1
+        with:
+          url: https://honglee.vercel.app/ko

--- a/apps/portfolio/features/main/components/Main.tsx
+++ b/apps/portfolio/features/main/components/Main.tsx
@@ -35,14 +35,13 @@ const LangToggle = styled.div`
 const LangBtn = styled(Link, {
   shouldForwardProp: (prop) => prop !== "$active",
 })<{ $active: boolean }>`
-  color: black;
+  color: ${({ $active }) => ($active ? "#000000" : "#767676")};
   text-decoration: none;
-  opacity: ${({ $active }) => ($active ? 1 : 0.3)};
   pointer-events: ${({ $active }) => ($active ? "none" : "auto")};
-  transition: opacity 0.2s;
+  transition: color 0.2s;
 
   &:hover {
-    opacity: 1;
+    color: #000000;
   }
 `;
 


### PR DESCRIPTION
- Add GitHub Actions workflow using seoulcircle/a11y-audit@v1
- Fix LangBtn inactive state: opacity 0.3 → color #767676 (WCAG AA 4.54:1)